### PR TITLE
Restricting configure command to admin users only

### DIFF
--- a/harambot/cogs/meta.py
+++ b/harambot/cogs/meta.py
@@ -71,8 +71,10 @@ class Meta(commands.Cog):
         await interaction.response.send_message(self.bot.latency)
 
     @app_commands.command(
-        name="configure", description="Configure your guild for Harambot"
+        name="configure",
+        description="Configure your guild for Harambot",
     )
+    @app_commands.checks.has_permissions(administrator=True)
     async def configure(self, interaction: discord.Interaction):
         await interaction.response.send_message(
             """
@@ -83,3 +85,12 @@ class Meta(commands.Cog):
             view=ConfigView(),
             ephemeral=True,
         )
+
+    @configure.error
+    async def configure_check_error(
+        self, interaction: discord.Interaction, error
+    ):
+        if isinstance(error, app_commands.MissingPermissions):
+            await interaction.response.send_message(
+                "You do not have the required permissions to run this command."
+            )


### PR DESCRIPTION
## Description

Restricts the configure command to only users with administrator permissions.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* #75 